### PR TITLE
OSW-851: Add pool_pre_ping to sqlalchemy create_async_engine.

### DIFF
--- a/doc/news/OSW-851.perf.rst
+++ b/doc/news/OSW-851.perf.rst
@@ -1,0 +1,1 @@
+Added pool_pre_ping to sqlalchemy create_async_engine.

--- a/python/lsst/ts/nightreport/database.py
+++ b/python/lsst/ts/nightreport/database.py
@@ -49,7 +49,7 @@ class NightReportDatabase:
         self.logger = structlog.get_logger("NightReportDatabase")
         sa_url = sqlalchemy.engine.make_url(url)
         sa_url = sa_url.set(drivername="postgresql+asyncpg")
-        self.engine = create_async_engine(sa_url, future=True)
+        self.engine = create_async_engine(sa_url, future=True, pool_pre_ping=True)
         self.nightreport_table = nightreport_table
         self.start_task = asyncio.create_task(self.start())
 


### PR DESCRIPTION
This PR adds the `pool_pre_ping` option to the sqlalchemy `create_async_engine` in order to improve the behavior for idle connections.